### PR TITLE
Chang make project OPRF-PSI run success!

### DIFF
--- a/compile
+++ b/compile
@@ -6,12 +6,19 @@ cd libOTe
 git checkout a2bc326
 cd cryptoTools
 git checkout 2607541
-cd thirdparty/linux
-bash all.get
+cd thirdparty/linux 
+wget -c 'https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.bz2' -O ./boost_1_69_0.tar.bz2
+tar xfj boost_1_69_0.tar.bz2
+mv boost_1_69_0 boost
+rm  boost_1_69_0.tar.bz2
+cd ./boost
+./bootstrap.sh
+./b2 stage --with-system --with-thread link=static -mt
+cd ../
+bash miracl.get
 cd ../../..
 cmake -D ENABLE_MIRACL=ON .
 make
 cd ../OPRF-PSI
 cmake .
 make
-


### PR DESCRIPTION
Hi, I have recently been very interested in your paper Private Set Intersection in the Internet Setting From Lightweight Oblivious PRF published at CRYPTO 2020, by researching the whole paper, I found it to be a meaningful work. But in the code part of the thesis I have the same problem as xiaoxin-zhang1209. After my experimental analysis, I found that it is not your problem, the problem is in the libOTe project: the code download source in the libOTe/thirdparty/linux/boost.get file https://dl.bintray.com/ has stopped serving, so I replaced a download source https://boostorg.jfrog.io/. I put all the command operations that need to be changed in the compile file under OPRF/PSI. After my operations, the experiment can be run!