### PR TITLE
Change to make the succesful number of PSI clear.

### DIFF
--- a/PSI/src/PsiReceiver.cpp
+++ b/PSI/src/PsiReceiver.cpp
@@ -252,9 +252,9 @@ namespace PSI {
 			}
 		}
 		
-		if (psi == 100) {
-			std::cout << "Receiver intersection computed - correct!\n";
-		}
+		//if (psi == 100) {
+			std::cout << "Receiver intersection computed Number is [" << psi << "]\n";
+		//}
 		timer.setTimePoint("Receiver intersection computed");
 		
 		


### PR DESCRIPTION
Hello, after I run the code, the result is only "Receiver intersection computed -correct!". This result makes me at a loss, because I want to get the specific number of PSI successes. In fact, after analyzing the code, the code sets the first 100 sets of the two sides to be equal, which is a good way to prevent the number of PSI intersections from becoming smaller. Finally, in order to get the number of specific PSI successes, I modified the project OPRF-PSI\PSI\src\PsiReceiver.cpp file. In the end I also got satisfactory data. For example, when I adjust the parameters w and h to a small value, the corresponding number of successful PSI intersections will be significantly greater than 100.